### PR TITLE
ci(dependabot): remove legacy npm dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,6 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-  - package-ecosystem: npm
-    directory: '/browser-extension'
-    schedule:
-      interval: 'daily'
   - package-ecosystem: "uv"
     directory: "backend/"
     schedule:


### PR DESCRIPTION
This PR removes the npm dependabot config part